### PR TITLE
feat: Optimize image loading for LCP and performance

### DIFF
--- a/assets/js/course-details.js
+++ b/assets/js/course-details.js
@@ -226,8 +226,9 @@ document.addEventListener("DOMContentLoaded", () => {
              <source srcset="${imageBase}-small.webp 800w, ${imageBase}-large.webp 1200w" sizes="(max-width: 991px) 95vw, 50vw" type="image/webp">
              <source srcset="${imageBase}-small.jpg 800w, ${imageBase}-large.jpg 1200w" sizes="(max-width: 991px) 95vw, 50vw" type="image/jpeg">
              <img src="${imageBase}-large.jpg" alt="${course.title}" class="img-fluid rounded shadow"
-                  loading="lazy" width="600" height="400"
-                  onerror="this.onerror=null; this.src='${fallbackImage}';">
+                  width="600" height="400"
+                  onerror="this.onerror=null; this.src='${fallbackImage}';"
+                  loading="eager" fetchpriority="high" decoding="async">
           </picture>
         </div>
         <div class="col-lg-6">

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -98,7 +98,8 @@ function createCourseCard(course) {
                   src="${imageBase}-large.jpg"
                   alt="${course.title}"
                   onerror="this.onerror=null; this.src='${finalFallbackImage}';"
-                  width="400" height="210">
+                  width="400" height="210"
+                  loading="lazy" fetchpriority="low" decoding="async">
           </picture>
           <span class="badge bg-${COURSE_DATA.categories[course.category]?.color || 'success'} course-category">${course.category}</span>
         </div>
@@ -130,6 +131,18 @@ function createCourseCard(course) {
     </div>
   `;
 }
+
+function optimizeVisibleImages() {
+      const cards = qsa('.course-card');
+      const visibleCards = cards.slice(0, 3);
+      visibleCards.forEach(card => {
+        const img = qs('img', card);
+        if (img) {
+          img.loading = 'eager';
+          img.fetchPriority = 'high';
+        }
+      });
+    }
 
 
   // === MAIN FILTER & SORT SYSTEM ===
@@ -390,6 +403,7 @@ function createCourseCard(course) {
             courseElement.style.animationDelay = `${index * 0.1}s`;
             container.appendChild(courseElement);
           });
+          optimizeVisibleImages();
         }
 
         // Update results text


### PR DESCRIPTION
- Implemented a dynamic image loading strategy to improve the Largest Contentful Paint (LCP) and overall performance.
- Course card images now default to `loading="lazy"` and `fetchpriority="low"`.
- A new post-render optimization function upgrades the first 3 visible card images to `loading="eager"` and `fetchpriority="high"`.
- The main image on the course details page is now set to load eagerly with high priority.
- This ensures critical images are loaded first while deferring off-screen images, adapting to user filtering and sorting actions.